### PR TITLE
Add Google custom search engine to page

### DIFF
--- a/_sass/gcse_overrides.scss
+++ b/_sass/gcse_overrides.scss
@@ -1,0 +1,64 @@
+#___gcse_0 {
+  table {
+    margin-top: 0;
+    margin-bottom: 0;
+    border: none;
+    td {
+      border: none;
+      // padding: unset;
+      padding-top: inherit;
+      padding-bottom: inherit;
+      &.gsc-search-button {
+        padding: 0;
+      }
+      &.gsc-input {
+        padding-left: 0;
+        padding-right: 12px;
+        #gs_tti50{
+          padding-top: 4px;
+          padding-bottom: 2px;
+        }
+        #gs_st50 {
+          line-height: 1;
+        }
+      }
+    }
+  }
+  .gsc-above-wrapper-area {
+    table {
+      td {
+        padding-left: 0;
+        padding-right: 0;
+      }
+    }
+  }
+  div.gsc-control-cse {
+    padding: 0;
+  }
+  table.gsc-table-result {
+    padding-left: 0;
+    margin-left: 8px;
+  }
+  .gs-result .gs-title, .gs-result .gs-title * {
+    text-decoration: unset;
+  }
+  .gs-result div.gs-title > a.gs-title {
+        // font-weight: bolder;
+        margin-bottom: 0;
+        font-family: monospace;
+
+        text-decoration: none;
+        cursor: pointer;
+        color: $link-color;
+        &:hover, &:hover b {
+            text-decoration: underline;
+            color: $hover-color;
+        }
+        &:visited {
+            color: $hover-color;
+        }
+        b {
+          font-weight: bolder;
+        }
+    }
+}

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -12,6 +12,8 @@ $header-color: #111;
 $link-color: #d32f2f;
 $hover-color: #673ab7;
 
+@import "gcse_overrides";
+
 // Override Minima
 .site-footer {
     border-top: none;

--- a/search.md
+++ b/search.md
@@ -1,0 +1,18 @@
+---
+layout: page
+title: Search
+permalink: /search/
+---
+
+<script>
+  (function() {
+    var cx = '016052200310965814730:fjdddpl3qnm';
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gcse, s);
+  })();
+</script>
+<gcse:search></gcse:search>


### PR DESCRIPTION
Create a /search/ subpage to incorporate [Google Custom Search Engine](https://cse.google.com/cse/). This allows users of my page to search its contents within the page. It's equivalent of using `site:maks.kolman.si` in a normal Google search query.